### PR TITLE
Fix imports: <climits> to src/synth.cpp

### DIFF
--- a/src/synth.cpp
+++ b/src/synth.cpp
@@ -25,6 +25,7 @@
 #include "miditable.h"
 #include <algorithm>
 #include <math.h>
+#include <climits>
 
 using namespace Steinberg;
 


### PR DESCRIPTION
See issue #17 for reference

Note I have not tested this build on windows or mac OS, so I can't check if the addition of this import breaks compiles for other platforms.